### PR TITLE
fix(scan): stop aborting package lookups on transient upstream errors

### DIFF
--- a/internal/scan/vdb_lookup.go
+++ b/internal/scan/vdb_lookup.go
@@ -125,9 +125,13 @@ func LookupVulns(
 					firstErr = err
 				}
 				errMu.Unlock()
-				// Cancel remaining lookups — if one fails due to rate limit
-				// or auth error, the rest will too.
-				cancel()
+				// Only abort the whole batch on errors every worker will share:
+				// auth (401/403) or quota exhausted after fallback (429). Transient
+				// upstream errors (5xx, timeouts) already retry in the client, so
+				// one worker's failure shouldn't cancel the others.
+				if isFatalBatchError(err) {
+					cancel()
+				}
 			} else {
 				errMu.Lock()
 				stats.Succeeded++
@@ -256,4 +260,18 @@ func lookupOnePackage(ctx context.Context, client *vdb.Client, key PackageLookup
 		return findings, nil
 	}
 	return nil, nil
+}
+
+// isFatalBatchError reports whether an error from a single package lookup
+// implies every other concurrent lookup will also fail. These are errors
+// tied to identity or plan state (auth, quota after fallback) rather than
+// transient per-request upstream issues — which the client already retries.
+func isFatalBatchError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "API error (401)") ||
+		strings.Contains(s, "API error (403)") ||
+		strings.Contains(s, "quota exhausted")
 }


### PR DESCRIPTION
## Summary
- When one package lookup failed mid-scan, the cancellable context was cancelled unconditionally, aborting every other in-flight and queued worker — so a single 502/503 from the VDB API killed the whole scan.
- The VDB client (`pkg/vdb/client.go`) already retries 429/502/503/504 with exponential backoff. Peer workers should not be cancelled when one sees a transient upstream hiccup.
- Now only cancel on errors every worker will share: auth failures (401/403) and quota exhausted after community fallback.

## Background
Paired with vdb-manager PR that raises API capacity floor and adds request-count autoscaling. Users on unlimited plans were seeing 5xx bursts during concurrent SCA scans; quota enforcement uses 429, so these were infrastructure-driven, not quota-driven. This change keeps the CLI from amplifying a single transient error into a full scan abort.

## Test plan
- [ ] `go build ./...` passes
- [ ] Manual: run `vulnetix sca` against a project that previously aborted and confirm it completes even when individual lookups 5xx after retries
- [ ] Verify scan still aborts fast on bad credentials (401/403)